### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/style-and-lint.yaml
+++ b/.github/workflows/style-and-lint.yaml
@@ -1,5 +1,8 @@
 name: Code quality tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/davep/oldnews/security/code-scanning/1](https://github.com/davep/oldnews/security/code-scanning/1)

In general, the fix is to explicitly restrict the `GITHUB_TOKEN` permissions for this workflow to the minimum needed. For a pure style/lint workflow that only checks out code and runs local commands, `contents: read` is sufficient. This is best added at the workflow root level so it applies to all jobs (currently just `style-and-lint`) without repeating configuration.

Concretely, in `.github/workflows/style-and-lint.yaml`, add a `permissions:` block near the top, alongside `name:` and `on:`. For example, insert:

```yaml
permissions:
  contents: read
```

between the `name:` and the `on:` keys. No changes are needed to jobs or steps, and no additional imports or external libraries are required. This documents the intended minimal access and ensures the workflow remains restricted if repo/org defaults change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
