### PR TITLE
Fix default app CSS being lost

### DIFF
--- a/src/oldnews/oldnews.py
+++ b/src/oldnews/oldnews.py
@@ -59,11 +59,12 @@ class OldNews(EnhancedApp[None]):
     this program. If not, see <https://www.gnu.org/licenses/>.
     """
 
-    CSS = """
-    * {
+    CSS = f"""
+    {EnhancedApp.CSS}
+    * {{
         /* https://github.com/Textualize/textual/issues/6349 */
         pointer: default;
-    }
+    }}
     """
 
     COMMANDS = set()


### PR DESCRIPTION
The fix for Textual's `pointer` FUBAR also meant I was overriding the default app styling from `textual-enhanced`. This works around that.