### PR TITLE
Background marking an article as read on the server

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # OldNews ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- More changes to how, when and where an article is marked as read when it
+  is displayed.
+
 ## v0.10.0
 
 **Released: 2026-02-08**

--- a/src/oldnews/screens/main.py
+++ b/src/oldnews/screens/main.py
@@ -452,18 +452,27 @@ class Main(EnhancedScreen[None]):
         """Handle changes to the show all flag."""
         await self._refresh_article_list()
 
+    @work
+    async def _remotely_mark_read(self, article: Article) -> None:
+        """Mark an article as read on the TheOldReader server.
+
+        Args:
+            article: The article to mark as read.
+        """
+        await article.mark_read(self._session)
+
     async def _mark_read(self, article: Article) -> None:
         """Mark the given article as read.
 
         Args:
             article: The article to mark as read.
         """
+        self._remotely_mark_read(article)
         await locally_mark_read(article)
         self.post_message(
             self.NewUnread(await get_local_unread(self.folders, self.subscriptions))
         )
         await self._refresh_article_list()
-        await article.mark_read(self._session)
 
     @on(ArticleContent.Displayed)
     async def _article_in_view(self, message: ArticleContent.Displayed) -> None:


### PR DESCRIPTION
Originally I was doing all the marking as read in the background, and this seemed to be the cause of #125. The change I made that I felt would fix that also made reading feel more responsive, *but* if the server was slow it would cause the whole process to pause for a good fraction of a second (or even longer if ToR was being very slow to respond).

Here I go half way: all local updates are done and awaited, but the remote mark as read is done in the background. Generally this should be fine because I only work off the local status anyway.